### PR TITLE
v0.1.5 - Fix for paths with white spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5 - beta
+
+* Fix for paths having white spaces
+
 ## 0.1.4 - beta
 
 * Smoothen the scrubber animation

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -286,7 +286,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.1.5"
   xml:
     dependency: transitive
     description:

--- a/lib/video_trimmer.dart
+++ b/lib/video_trimmer.dart
@@ -207,7 +207,7 @@ class Trimmer {
     }
 
     String _trimLengthCommand =
-        '-i $_videoPath -ss $startPoint -t ${endPoint - startPoint}';
+        '-i "$_videoPath" -ss $startPoint -t ${endPoint - startPoint}';
 
     if (ffmpegCommand == null) {
       _command = '$_trimLengthCommand -c copy ';
@@ -227,7 +227,7 @@ class Trimmer {
       _outputFormatString = customVideoFormat;
     }
 
-    _command += '$path$videoFileName$_outputFormatString';
+    _command += '"$path$videoFileName$_outputFormatString"';
 
     await _flutterFFmpeg.execute(_command).whenComplete(() {
       print('Got value');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_trimmer
 description: A Flutter package for trimming videos. This supports retrieving, trimming, and storage of trimmed video files to the file system.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/sbis04/video_trimmer
 
 environment:


### PR DESCRIPTION
Fixed the issue with the input and output video **paths having white spaces**.

Fix: #9  