### PR TITLE
v0.2.2 - Returns output video path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ build/
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 .vscode/settings.json
 example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+.vscode/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.2 - beta
+
+* Change implementation of the `saveTrimmedVideo()` method
+* `saveTrimmedVideo()` now returns the output video path
+* Update Docs
+
 ## 0.2.1 - beta
 
 * Fix over-scrolling && scroll-over issue

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -110,8 +110,9 @@ class _TrimmerViewState extends State<TrimmerView> {
                   onPressed: _progressVisibility
                       ? null
                       : () async {
-                          _saveVideo().then((value) {
-                            final snackBar = SnackBar(content: Text(value));
+                          _saveVideo().then((outputPath) {
+                            print('OUTPUT PATH: $outputPath');
+                            final snackBar = SnackBar(content: Text('Video Saved successfully'));
                             Scaffold.of(context).showSnackBar(snackBar);
                           });
                         },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -293,7 +293,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.2"
   xml:
     dependency: transitive
     description:

--- a/lib/video_trimmer.dart
+++ b/lib/video_trimmer.dart
@@ -87,6 +87,8 @@ class Trimmer {
   }
 
   /// Saves the trimmed video to file system.
+  /// 
+  /// Returns the output video path
   ///
   /// The required parameters are [startValue] & [endValue].
   ///
@@ -170,7 +172,8 @@ class Trimmer {
         .format(DateTime.now())
         .toString();
 
-    String _resultString;
+    // String _resultString;
+    String _outputPath;
     String _outputFormatString;
     String formattedDateTime = dateTime.replaceAll(' ', '');
 
@@ -231,17 +234,21 @@ class Trimmer {
       _outputFormatString = customVideoFormat;
     }
 
-    _command += '"$path$videoFileName$_outputFormatString"';
+    _outputPath = '"$path$videoFileName$_outputFormatString"';
+
+    _command += _outputPath;
 
     await _flutterFFmpeg.execute(_command).whenComplete(() {
       print('Got value');
-      _resultString = 'Video successfuly saved';
+      debugPrint('Video successfuly saved');
+      // _resultString = 'Video successfuly saved';
     }).catchError((error) {
       print('Error');
-      _resultString = 'Couldn\'t save the video';
+      // _resultString = 'Couldn\'t save the video';
+      debugPrint('Couldn\'t save the video');
     });
 
-    return _resultString;
+    return _outputPath;
   }
 
   /// For getting the video controller state, to know whether the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_trimmer
 description: A Flutter package for trimming videos. This supports retrieving, trimming, and storage of trimmed video files to the file system.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/sbis04/video_trimmer
 
 environment:


### PR DESCRIPTION
## Changes
* `saveTrimmedVideo()` now returns the output video path
* Update Docs

## Fix
* Fixes the issue of retrieving output video path: #18 