### PR TITLE
Change trimming start and end positions from dialog.

### DIFF
--- a/lib/trim_editor.dart
+++ b/lib/trim_editor.dart
@@ -278,7 +278,7 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
     _animationController.reset();
   }
 
-  
+
   void _setVideoEndByCtrl(double time) async {
 
     setState(() {
@@ -810,6 +810,15 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
                                   .split('.')[0],
                               style: widget.durationTextStyle),
                         ),
+                        ValueListenableBuilder(
+                          valueListenable: videoPlayerController,
+                          builder: (context, VideoPlayerValue value, child) {
+                            return Text(
+                                value.position.toString().split('.')[0],
+                                style: widget.durationTextStyle);
+                          },
+                        ),
+
                         GestureDetector(
                           onTap: () {
                             setCtrlTimes(_videoEndPos, start: false);

--- a/lib/trim_editor.dart
+++ b/lib/trim_editor.dart
@@ -261,17 +261,12 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
     }
   }
 
-  // Sets the start value of video.
-  // Assumes that ThumbnailViewer is screen width - 10
+
   void _setVideoStartByCtrl(double time) async {
-    double widgetWidth = MediaQuery
-        .of(context)
-        .size
-        .width - 10;
     setState(() {
       _videoStartPos = time;
       _startFraction = _videoStartPos / _videoDuration;
-      _startPos = Offset(_startFraction * widgetWidth, _startPos.dy);
+      _startPos = Offset(_startFraction * widget.viewerWidth, _startPos.dy);
       widget.onChangeStart(_videoStartPos);
     });
 
@@ -283,17 +278,13 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
     _animationController.reset();
   }
 
-  // Sets the end value of video.
-  // Assumes that ThumbnailViewer is screen width - 10
+  
   void _setVideoEndByCtrl(double time) async {
-    double widgetWidth = MediaQuery
-        .of(context)
-        .size
-        .width - 10;
+
     setState(() {
       _videoEndPos = time;
       _endFraction = _videoEndPos / _videoDuration;
-      _endPos = Offset(_endFraction * widgetWidth, _endPos.dy);
+      _endPos = Offset(_endFraction * widget.viewerWidth, _endPos.dy);
 
       widget.onChangeEnd(_videoEndPos);
     });


### PR DESCRIPTION
This feature allows to open trim start and end time controlling dialog by tapping duration texts.

Dialog input fields are synced with trim editor painter. Dialog has TextFields and buttons for increasing or decreasing start or end time by one time unit. Inputs are limited to specific numbers on same range as trim editor painter. Erroneous input is interpreted as 0:0:0.0 if starting point is not moved from start, otherwise as starting point

I use this in app where it's common to trim 1-10 min clips to 5 seconds clips. This feature helps a lot to get more exact cut.

![video_trim_gif](https://user-images.githubusercontent.com/52159726/87977157-f296c280-cad6-11ea-9aae-d3e8afbbbf31.gif)
