### PR TITLE
Enable single frame snapshots.

### DIFF
--- a/lib/src/trimmer.dart
+++ b/lib/src/trimmer.dart
@@ -217,8 +217,10 @@ class Trimmer {
       _outputFormatString = outputFormat.toString();
     }
 
-    String _trimLengthCommand =
-        '-i "$_videoPath" -ss $startPoint -t ${endPoint - startPoint}';
+    String _trimLengthCommand = '-i "$_videoPath" -ss $startPoint';
+    if (endPoint > startPoint) {
+      _trimLengthCommand += ' -t ${endPoint - startPoint}';
+    }
 
     if (ffmpegCommand == null) {
       _command = '$_trimLengthCommand -c:a copy ';


### PR DESCRIPTION
To enable single frame snapshots, only add the ffmpeg `-t` argument if the end point is greater than the start point. This resolves PR https://github.com/sbis04/video_trimmer/issues/61, because the client can pass in a custom ffmpeg argument to fetch out a single frame:

```
final position = videoPlayerController.value.position.inMilliseconds.toDouble();

await trimmer.saveTrimmedVideo(
   startValue: position,
   endValue: position,
   customVideoFormat: '.jpg',
   ffmpegCommand: '-frames:v 1');
```