### PR TITLE
Initial start and end parameters for `TrimEditor`

### DIFF
--- a/example/lib/trimmer_view.dart
+++ b/example/lib/trimmer_view.dart
@@ -82,6 +82,8 @@ class _TrimmerViewState extends State<TrimmerView> {
                   child: TrimEditor(
                     viewerHeight: 50.0,
                     viewerWidth: MediaQuery.of(context).size.width,
+                    initStartDuration: Duration(seconds: 1),
+                    initEndDuration: Duration(seconds: 3),
                     maxVideoLength: Duration(seconds: 10),
                     onChangeStart: (value) {
                       _startValue = value;


### PR DESCRIPTION
I introduced the ability to initialize `TrimEditor` with predefined start and end values.

The sample usage looks like:
```
                  child: TrimEditor(
                    viewerHeight: 50.0,
                    viewerWidth: MediaQuery.of(context).size.width,
                    initStartDuration: Duration(seconds: 1),
                    initEndDuration: Duration(seconds: 3),
                    maxVideoLength: Duration(seconds: 10),
                    onChangeStart: (value) {
                      _startValue = value;
                    },
                    onChangeEnd: (value) {
                      _endValue = value;
                    },
                    onChangePlaybackState: (value) {
                      setState(() {
                        _isPlaying = value;
                      });
                    },
                  ),
```