### PR TITLE
dispose of trimmer controller in the example.

### DIFF
--- a/example/lib/trimmer_view.dart
+++ b/example/lib/trimmer_view.dart
@@ -27,6 +27,12 @@ class _TrimmerViewState extends State<TrimmerView> {
 
     _loadVideo();
   }
+  
+  @override
+  void dispose() {
+    _trimmer.dispose();
+    super.dispose();
+  }
 
   void _loadVideo() {
     _trimmer.loadVideo(videoFile: widget.file);


### PR DESCRIPTION
After disposing of the "trimmer_view" in the example folder. Dispose of the trimmer controller too.