### PR TITLE
add optional scroll time parameter

### DIFF
--- a/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
+++ b/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
@@ -74,6 +74,9 @@ class ScrollableTrimViewer extends StatefulWidget {
 
   final VoidCallback onThumbnailLoadingComplete;
 
+  /// A value that will represent how long before the viewer will start scrolling in milliseconds
+  final int scrollDelay;
+
   /// Widget for displaying the video trimmer.
   ///
   /// This has frame wise preview of the video with a
@@ -123,6 +126,7 @@ class ScrollableTrimViewer extends StatefulWidget {
     required this.trimmer,
     required this.maxVideoLength,
     required this.onThumbnailLoadingComplete,
+    this.scrollDelay = 300,
     this.viewerWidth = 50 * 8,
     this.viewerHeight = 50,
     this.showDuration = true,
@@ -205,7 +209,7 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
 
   void startScrolling(bool isTowardsEnd) {
     _scrollingTimer =
-        Timer.periodic(const Duration(milliseconds: 300), (timer) {
+        Timer.periodic(Duration(milliseconds: widget.scrollDelay), (timer) {
       setState(() {
         final midPoint = (_endPos.dx - _startPos.dx) / 2;
         var speedMultiplier = 1;
@@ -263,7 +267,7 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
   }
 
   void startTimer(bool isTowardsEnd) {
-    var start = 300;
+    var start = widget.scrollDelay;
     _scrollStartTimer = Timer.periodic(
       const Duration(milliseconds: 100),
       (Timer timer) {
@@ -649,7 +653,8 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
                     ),
                     _scrollController.positions.isNotEmpty
                         ? AnimatedContainer(
-                            duration: const Duration(milliseconds: 300),
+                            duration:
+                                Duration(milliseconds: widget.scrollDelay),
                             decoration: BoxDecoration(
                               gradient: widget.areaProperties.blurEdges
                                   ? LinearGradient(
@@ -678,7 +683,8 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
                                         _scrollController.position.pixels != 0.0
                                             ? 1.0
                                             : 0.0,
-                                    duration: const Duration(milliseconds: 300),
+                                    duration: Duration(
+                                        milliseconds: widget.scrollDelay),
                                     child: widget.areaProperties.startIcon),
                                 const Spacer(),
                                 AnimatedOpacity(
@@ -687,7 +693,8 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
                                               .position.maxScrollExtent
                                       ? 1.0
                                       : 0.0,
-                                  duration: const Duration(milliseconds: 300),
+                                  duration: Duration(
+                                      milliseconds: widget.scrollDelay),
                                   child: widget.areaProperties.endIcon,
                                 ),
                               ],

--- a/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
+++ b/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
@@ -126,7 +126,7 @@ class ScrollableTrimViewer extends StatefulWidget {
     required this.trimmer,
     required this.maxVideoLength,
     required this.onThumbnailLoadingComplete,
-    this.scrollDelay = 300,
+    required this.scrollDelay,
     this.viewerWidth = 50 * 8,
     this.viewerHeight = 50,
     this.showDuration = true,

--- a/lib/src/trim_viewer/trim_viewer.dart
+++ b/lib/src/trim_viewer/trim_viewer.dart
@@ -36,6 +36,10 @@ class TrimViewer extends StatefulWidget {
   /// By default it is set to `ViewerType.auto`.
   final ViewerType type;
 
+  /// For defining the delay in a scrollable viewer in milliseconds
+  /// Scrollviewer defaults to 300 milliseconds
+  final int? scrollDelay;
+
   /// For defining the maximum length of the output video.
   ///
   /// **NOTE:** When explicitly setting the `type` to `scrollable`,
@@ -184,6 +188,7 @@ class TrimViewer extends StatefulWidget {
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const TrimAreaProperties(),
     this.onThumbnailLoadingComplete,
+    this.scrollDelay,
   }) : super(key: key);
 
   @override
@@ -222,6 +227,7 @@ class _TrimViewerState extends State<TrimViewer> with TickerProviderStateMixin {
   Widget build(BuildContext context) {
     final scrollableViewer = ScrollableTrimViewer(
       trimmer: widget.trimmer,
+      scrollDelay: widget.scrollDelay ?? 300,
       maxVideoLength: widget.maxVideoLength,
       viewerWidth: widget.viewerWidth,
       viewerHeight: widget.viewerHeight,


### PR DESCRIPTION
Responding to #199 

Added a property [scrollDelay] in the ScrollableTrimViewer that will switch the hardcoded 300 milliseconds in each of the animations and wait times to this value.
Added an optional input to the parent TrimViewer that will accept a value to be passed along. If no value is given, it will default back to the 300ms. 

When dropping the value from 300ms, the trimviewer is quicker to respond to scrolling the timeline and has more of a consistent scroll effect over the delayed and fragmented motions