### PR TITLE
Loosens dependencies

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cross_file:
     dependency: transitive
     description:
@@ -239,7 +239,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   csslib:
     dependency: transitive
     description:
@@ -215,7 +215,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  video_player: ^2.9.2
-  ffmpeg_kit_flutter: ^6.0.3
-  path_provider: ^2.1.1
+  video_player: ^2.0.0
+  ffmpeg_kit_flutter: ^6.0.0
+  path_provider: ^2.0.0
   intl: ^0.20.0
-  path: ^1.9.1
-  transparent_image: ^2.0.1
+  path: ^1.8.0
+  transparent_image: ^2.0.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
Currently video_trimmer is fairly incompatible with other plugins/packages because all of its dependencies are updated to the latest version. This sets the minimum version of all dependencies to the oldest compatible version. Aka, it keeps the major version, but drops the minor version for compatibilities sake.