### PR TITLE
Feature: optional initial start and end values on initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * Supports two types of trim viewer, fixed length and scrollable.
 * Video playback control.
 * Retrieving and storing video file.
+* _(This fork)_ Optional initial trim range: pass `initialStartValue`/`initialEndValue` (ms) to show a saved range when returning to the step; playback starts within the selected range.
 
 Also, supports conversion to **GIF**.
 

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -68,6 +68,11 @@ class FixedTrimViewer extends StatefulWidget {
 
   final VoidCallback onThumbnailLoadingComplete;
 
+  /// OpenMic fork: optional initial trim range in milliseconds. When set, the trimmer
+  /// shows this range instead of full video (e.g. to restore a saved trim).
+  final double? initialStartValue;
+  final double? initialEndValue;
+
   /// Widget for displaying the video trimmer.
   ///
   /// This has frame wise preview of the video with a
@@ -127,6 +132,8 @@ class FixedTrimViewer extends StatefulWidget {
     this.onChangePlaybackState,
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const FixedTrimAreaProperties(),
+    this.initialStartValue,
+    this.initialEndValue,
   });
 
   @override
@@ -228,16 +235,34 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
           maxLengthPixels = _thumbnailViewerW;
         }
 
-        _videoEndPos = fraction != null
+        final double maxEndMs = fraction != null
             ? _videoDuration.toDouble() * fraction!
             : _videoDuration.toDouble();
 
-        widget.onChangeEnd!(_videoEndPos);
-
-        _endPos = Offset(
-          maxLengthPixels != null ? maxLengthPixels! : _thumbnailViewerW,
-          _thumbnailViewerH,
-        );
+        // OpenMic fork: optional initial trim range so handles show saved range when returning to preview.
+        if (widget.initialStartValue != null &&
+            widget.initialEndValue != null) {
+          final startMs =
+              widget.initialStartValue!.clamp(0.0, _videoDuration.toDouble());
+          final endMs = widget.initialEndValue!.clamp(startMs, maxEndMs);
+          _videoStartPos = startMs;
+          _videoEndPos = endMs;
+          _startFraction = _videoDuration > 0 ? startMs / _videoDuration : 0.0;
+          _endFraction = _videoDuration > 0 ? endMs / _videoDuration : 1.0;
+          // OpenMic fork: use _thumbnailViewerW so position matches drag handlers (_startPos.dx / _thumbnailViewerW).
+          _startPos = Offset(_thumbnailViewerW * _startFraction, 0);
+          _endPos = Offset(_thumbnailViewerW * _endFraction, _thumbnailViewerH);
+          if (widget.onChangeStart != null)
+            widget.onChangeStart!(_videoStartPos);
+          if (widget.onChangeEnd != null) widget.onChangeEnd!(_videoEndPos);
+        } else {
+          _videoEndPos = maxEndMs;
+          widget.onChangeEnd!(_videoEndPos);
+          _endPos = Offset(
+            maxLengthPixels != null ? maxLengthPixels! : _thumbnailViewerW,
+            _thumbnailViewerH,
+          );
+        }
 
         // Defining the tween points
         _linearTween = Tween(begin: _startPos.dx, end: _endPos.dx);

--- a/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
+++ b/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
@@ -75,6 +75,10 @@ class ScrollableTrimViewer extends StatefulWidget {
 
   final VoidCallback onThumbnailLoadingComplete;
 
+  /// OpenMic fork: optional initial trim range in milliseconds (API parity only; scrollable viewer does not apply them).
+  final double? initialStartValue;
+  final double? initialEndValue;
+
   /// Widget for displaying the video trimmer.
   ///
   /// This has frame wise preview of the video with a
@@ -134,6 +138,8 @@ class ScrollableTrimViewer extends StatefulWidget {
     this.paddingFraction = 0.2,
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const TrimAreaProperties(),
+    this.initialStartValue,
+    this.initialEndValue,
   });
 
   @override

--- a/lib/src/trim_viewer/trim_viewer.dart
+++ b/lib/src/trim_viewer/trim_viewer.dart
@@ -167,6 +167,11 @@ class TrimViewer extends StatefulWidget {
   /// * [onThumbnailLoadingComplete] is a callback for thumbnail loader to
   /// know when all the thumbnails are loaded.
   ///
+  /// OpenMic fork: optional initial trim range in milliseconds. When set, the trimmer
+  /// shows this range instead of full video (e.g. to restore a saved trim).
+  final double? initialStartValue;
+  final double? initialEndValue;
+
   const TrimViewer({
     super.key,
     required this.trimmer,
@@ -184,6 +189,8 @@ class TrimViewer extends StatefulWidget {
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const TrimAreaProperties(),
     this.onThumbnailLoadingComplete,
+    this.initialStartValue,
+    this.initialEndValue,
   });
 
   @override
@@ -239,6 +246,9 @@ class _TrimViewerState extends State<TrimViewer> with TickerProviderStateMixin {
           widget.onThumbnailLoadingComplete!();
         }
       },
+      // OpenMic fork: pass initial trim range to child viewer.
+      initialStartValue: widget.initialStartValue,
+      initialEndValue: widget.initialEndValue,
     );
 
     final fixedTrimViewer = FixedTrimViewer(
@@ -263,6 +273,9 @@ class _TrimViewerState extends State<TrimViewer> with TickerProviderStateMixin {
           widget.onThumbnailLoadingComplete!();
         }
       },
+      // OpenMic fork: pass initial trim range to child viewer.
+      initialStartValue: widget.initialStartValue,
+      initialEndValue: widget.initialEndValue,
     );
 
     return _isScrollableAllowed == null

--- a/lib/src/trimmer.dart
+++ b/lib/src/trimmer.dart
@@ -350,13 +350,19 @@ class Trimmer {
       await videoPlayerController!.pause();
       return false;
     } else {
-      if (videoPlayerController!.value.position.inMilliseconds >=
-          endValue.toInt()) {
+      // OpenMic fork: use position once and seek to trim start when before range so playback starts in range.
+      final positionMs = videoPlayerController!.value.position.inMilliseconds;
+      if (positionMs >= endValue.toInt()) {
         await videoPlayerController!
             .seekTo(Duration(milliseconds: startValue.toInt()));
         await videoPlayerController!.play();
         return true;
       } else {
+        // OpenMic fork: when position is before trim start, seek to start so playback begins in range.
+        if (positionMs < startValue.toInt()) {
+          await videoPlayerController!
+              .seekTo(Duration(milliseconds: startValue.toInt()));
+        }
         await videoPlayerController!.play();
         return true;
       }

--- a/lib/src/video_viewer.dart
+++ b/lib/src/video_viewer.dart
@@ -36,12 +36,12 @@ class VideoViewer extends StatefulWidget {
   /// area. By default it is set to `EdgeInsets.all(0.0)`.
   ///
   const VideoViewer({
-    Key? key,
+    super.key,
     required this.trimmer,
     this.borderColor = Colors.transparent,
     this.borderWidth = 0.0,
     this.padding = const EdgeInsets.all(0.0),
-  }) : super(key: key);
+  });
 
   @override
   State<VideoViewer> createState() => _VideoViewerState();


### PR DESCRIPTION
…lViewerW fix

- Optional initialStartValue/initialEndValue on TrimViewer/FixedTrimViewer/ScrollableTrimViewer
- Playback seeks to trim start when position is before range
- Use _thumbnailViewerW for initial positions to match drag handlers
- README: one line in Features for this fork