### PR TITLE
Fix: ScrollableTrimViewer auto-scroll never engages on iOS 26 due to drag-update cancel race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* **Fix**: `ScrollableTrimViewer` auto-scroll no longer engages on iOS 26 due to a drag-update cancel race with iOS's continuous zero-delta events. Only cancel the timer when leaving the trigger zone and only restart it when no timer is currently active.
+* **Fix**: `ScrollableTrimViewer` now fires `onChangeStart` / `onChangeEnd` while auto-scrolling, so consumers (duration labels, confirm-button enabled state, etc.) track the new selection instead of staying frozen at the values captured when scrolling started.
+
 ## 5.0.0
 
 Got rid of the `flutter_ffmpeg` package and now uses a **native video trimmer** (Android and iOS)! 🎉

--- a/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
+++ b/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
@@ -258,6 +258,13 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
           _remainingDuration;
       _videoStartPos = (_trimmerAreaDuration * _startFraction) + durationChange;
       _videoEndPos = (_trimmerAreaDuration * _endFraction) + durationChange;
+      // Notify the consumer so external state (e.g. duration label,
+      // confirm-button enabled state) tracks the new selection while
+      // auto-scroll is shifting the visible window. Without this, the
+      // selected range displayed outside the trimmer would stay frozen
+      // at the values captured when scrolling started.
+      widget.onChangeStart?.call(_videoStartPos);
+      widget.onChangeEnd?.call(_videoEndPos);
     });
     setState(() {});
   }
@@ -501,12 +508,28 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
     }
     // log('Video Duration :: Start: ${_videoStartPos / 1000}ms, End: ${_videoEndPos / 1000}ms');
     // log('UPDATE => START: ${_startPos.dx}, END: ${_endPos.dx}');
-    _scrollStartTimer?.cancel();
-    if (_endPos.dx >= _autoEndScrollPos &&
-        currentScrollValue <= totalVideoLengthInPixels) {
+    // Fix (iOS 26): only cancel the auto-scroll countdown timer when the
+    // trim window leaves the trigger zone, and only restart it when no
+    // timer is currently active.
+    //
+    // iOS 26 emits a stream of drag-update events with delta=0 even when
+    // the user's finger is stationary. The previous implementation called
+    // `_scrollStartTimer?.cancel()` unconditionally at the start of every
+    // drag-update, then re-scheduled the 300ms countdown via startTimer.
+    // With iOS 26's continuous zero-delta events, the timer was repeatedly
+    // cancelled before its 300ms could elapse, so startScrolling never ran
+    // and the user could not auto-scroll past the visible thumbnail strip.
+    final shouldStartEnd = _endPos.dx >= _autoEndScrollPos &&
+        currentScrollValue <= totalVideoLengthInPixels;
+    final shouldStartStart =
+        _startPos.dx <= _autoStartScrollPos && currentScrollValue != 0.0;
+    if (!shouldStartEnd && !shouldStartStart) {
+      _scrollStartTimer?.cancel();
+    }
+    if (shouldStartEnd && (_scrollStartTimer?.isActive ?? false) == false) {
       startTimer(true);
-    } else if (_startPos.dx <= _autoStartScrollPos &&
-        currentScrollValue != 0.0) {
+    } else if (shouldStartStart &&
+        (_scrollStartTimer?.isActive ?? false) == false) {
       startTimer(false);
     }
 


### PR DESCRIPTION
## Summary

On iOS 26, the auto-scroll feature of `ScrollableTrimViewer` never engages, leaving users unable to access video content beyond what is initially visible in the thumbnail strip. The trim window can be dragged to the right edge of the visible thumbnails, but holding it there does not trigger the expected scrolling. The same applies to the left edge.

## Root cause

iOS 26 emits a continuous stream of drag-update events with `delta=0` even while the user's finger is stationary (or moving very slowly with sub-pixel motion). The previous implementation of `_onDragUpdate` called `_scrollStartTimer?.cancel()` unconditionally at the start of every drag-update, then re-scheduled the 300ms countdown via `startTimer`. With iOS 26's continuous zero-delta events, the timer was repeatedly cancelled and re-scheduled before its 300ms could elapse, so `startScrolling` never ran and the user could not auto-scroll past the visible thumbnail strip.

## Fix

Only cancel the timer when the trim window leaves the trigger zone, and only restart it when no timer is currently active. This allows the 300ms countdown to complete naturally even while drag-updates continue to fire.

```dart
// Before
_scrollStartTimer?.cancel();
if (_endPos.dx >= _autoEndScrollPos && currentScrollValue <= totalVideoLengthInPixels) {
  startTimer(true);
} else if (_startPos.dx <= _autoStartScrollPos && currentScrollValue != 0.0) {
  startTimer(false);
}

// After
final shouldStartEnd = _endPos.dx >= _autoEndScrollPos &&
    currentScrollValue <= totalVideoLengthInPixels;
final shouldStartStart = _startPos.dx <= _autoStartScrollPos &&
    currentScrollValue != 0.0;
if (!shouldStartEnd && !shouldStartStart) {
  _scrollStartTimer?.cancel();
}
if (shouldStartEnd && (_scrollStartTimer?.isActive ?? false) == false) {
  startTimer(true);
} else if (shouldStartStart &&
    (_scrollStartTimer?.isActive ?? false) == false) {
  startTimer(false);
}
```

## Reproduction (without this fix)

1. Run an app using `video_trimmer` 5.0.0 on iOS 26 (tested on Simulator iOS 26.3 and physical device iOS 26.2.1)
2. Open `TrimViewer` with `type: ViewerType.scrollable` and a video long enough that the thumbnail strip needs to scroll (e.g., a 30-second video with `maxVideoLength: Duration(seconds: 10)`)
3. Center-drag the trim window to the right edge of the visible thumbnails
4. Hold the finger at the edge (or attempt to drag further right)
5. **Observed**: The thumbnail strip does NOT scroll. The user cannot reach the latter portion of the video.

The same failure mode occurs symmetrically at the left edge once the user has scrolled away from position 0.

## Verification (with this fix)

Verified on iOS 26.3 Simulator (iPhone 14 Plus) and physical iPhone iOS 26.2.1:

- `startTimer` countdown completes and `startScrolling` fires roughly 300ms after entering the trigger zone
- `_scrollController.animateTo` progresses incrementally through the scrollable range
- The user can now reach video positions far beyond the initially visible thumbnails

Example log trace from a 30-second video with `maxVideoLength = 10s`:

```
SCROLL: 40.0
SCROLL: 80.0
SCROLL: 120.0
...
SCROLL: 630.0
```

`currentPixels` of the scroll controller follows correspondingly (0 → 40 → 80 → ...).

In the resulting UX, a user can now select a 0:24-0:34 range from a 30-second video that previously was effectively limited to the first ~14 seconds of content.

## Files changed

- `lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart` (~15 substantive lines in `_onDragUpdate`)
- `CHANGELOG.md` (release note entry)